### PR TITLE
#52 ユーザー新規登録時のエラーメッセージを日本語に変更

### DIFF
--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,12 +1,12 @@
 <% if resource.errors.any? %>
   <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+    <h2 class="text-lg mb-2 text-error font-bold">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
     </h2>
-    <ul>
+    <ul class="text-error">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,10 +1,5 @@
-<h1 class="text-4xl font-bold">Hello world!</h1>
-<p>Find me in app/views/static_pages/home.html.erb</p>
-
-<button class="btn">Button</button>
-<button class="btn btn-neutral">Neutral</button>
-<button class="btn btn-primary">Primary</button>
-<button class="btn btn-secondary">Secondary</button>
-<button class="btn btn-accent">Accent</button>
-<button class="btn btn-ghost">Ghost</button>
-<button class="btn btn-link">Link</button>
+<div class="bg-white p-8 rounded-lg shadow-md text-center w-full">
+    <h1 class="text-4xl font-bold mb-4 text-accent">Hello Mutro!</h1>
+    <p class="text-gray-700 mb-4">Welcome to Mutro. Explore and enjoy our features.</p>
+    <%= link_to "Get Started", new_user_registration_path, class: "btn btn-primary hover:btn-primary-focus font-bold" %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,5 +7,6 @@ Bundler.require(*Rails.groups)
 module Mutro
   class Application < Rails::Application
     config.load_defaults 7.0
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,19 @@
+ja:
+  errors:
+    messages:
+      not_saved:
+        one: "1つのエラーが発生したため、%{resource}を保存できませんでした。"
+        other: "%{count}つのエラーが発生したため、%{resource}を保存できませんでした。"
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              blank: "メールアドレスを入力してください。"
+            password:
+              blank: "パスワードを入力してください。"
+  attributes:
+    email: "メールアドレス"
+    password: "パスワード"
+


### PR DESCRIPTION
- 仮トップページのデザインを変更しました。
- ユーザー新規登録時のエラーメッセージの色・サイズを仮で変更しました。
- ユーザー新規登録時のエラーメッセージを日本語で表示するように変更しました。