### PR TITLE
#67 プロフィール編集ページの作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,10 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
+    # 新規登録時のストロングパラメータ
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+
+    # プロフィール編集時のストロングパラメータ
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,15 +38,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-    protected
+  protected
 
-    def update_resource(resource, params)
-      resource.update_without_password(params)
-    end
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
 
-    def after_update_path_for(resource)
-      user_path(resource)
-    end
+  def after_update_path_for(resource)
+    user_path(resource)
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,7 +38,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+    protected
+
+    def update_resource(resource, params)
+      resource.update_without_password(params)
+    end
+
+    def after_update_path_for(resource)
+      user_path(resource)
+    end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :authenticate_user!, only: %i[show]
 
   def show
-    @user = User.find(params[:id])
+    @user = current_user
     redirect_to root_path unless current_user == @user
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,7 +1,9 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<%= current_user.name %>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
+
+
 
   <div class="field">
     <%= f.label :email %><br />
@@ -40,4 +42,4 @@
 
 <div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
 
-<%= link_to "Back", :back %>
+<%= link_to "マイページ", user_path(current_user), class: 'btn btn-sm btn-outline btn-primary'  %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,13 +1,17 @@
-<%= current_user.name %>
+<div class="text-primary font-bold">
+  ユーザー名：<%= current_user.name %>
+</div>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-
+  <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name, class: "input input-sm input-bordered", autocomplete: "name", autofocus: true %>
 
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, class: "input input-sm input-bordered", autofocus: true, autocomplete: "email" %>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
@@ -15,8 +19,8 @@
   <% end %>
 
   <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
+    <%= f.label :password %><br />
+    <%= f.password_field :password, class: "input input-sm input-bordered", autocomplete: "new-password" %>
     <% if @minimum_password_length %>
       <br />
       <em><%= @minimum_password_length %> characters minimum</em>
@@ -25,20 +29,13 @@
 
   <div class="field">
     <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
+    <%= f.password_field :password_confirmation, class: "input input-sm input-bordered", autocomplete: "new-password" %>
   </div>
 
   <div class="actions">
     <%= f.submit "Update" %>
   </div>
 <% end %>
-
-<h3>Cancel my account</h3>
 
 <div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -28,9 +28,8 @@
         <%= f.password_field :password_confirmation, class: "input input-sm input-bordered w-full", autocomplete: "new-password" %>
       </div>
 
-      <div class="btn btn-sm btn-outline btn-primary">
-        <%= f.submit "Sign up", class: "w-full" %>
-      </div>
+      <%= f.submit "Sign up", class: "btn btn-sm btn-outline btn-primary w-full" %>
+
     <% end %>
     <div class="mt-4">
       <%= render "devise/shared/links" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="navbar bg-base-100">
+<div class="navbar bg-base-100 pb-24">
   <div class="flex-1">
     <a><%= link_to 'Mutro', root_path, class: "btn btn-ghost normal-case text-2xl text-primary font-black" %></a>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,12 @@
-<h1><%= current_user.name%>'s My Page</h1>
-<p>ユーザーID: <%= current_user.id %></p>
-<div class="btn btn-sm btn-outline btn-primary">プロフィール編集</div>
-
+<div class="avatar">
+  <div class="w-40 rounded-full">
+    <%= image_tag 'K1Ey1wwTeYA6YQM1698909468_1698909495.png' %>
+  </div>
+</div>
+<div>
+  <%= current_user.name %>
+  <p>ユーザーID: <%= current_user.id %></p>
+</div>
+<% if user_signed_in? %>
+  <%= link_to 'プロフィール編集', edit_user_registration_path, class: 'btn btn-sm btn-outline btn-primary' %>
+<% end %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,10 +1,17 @@
 ja:
+  attributes:
+    name: "ユーザー名"
+    email: "メールアドレス"
+    password: "パスワード"
+    current_password: "現在のパスワード"
+    password_confirmation: "パスワード(確認用)"
   errors:
     messages:
       not_saved:
         one: "1つのエラーが発生したため、%{resource}を保存できませんでした。"
         other: "%{count}つのエラーが発生したため、%{resource}を保存できませんでした。"
       taken: "は既に使用されています。"
+      comfirmation: "が一致しません。"
   activerecord:
     errors:
       models:
@@ -14,15 +21,19 @@ ja:
               blank: "メールアドレスを入力してください。"
               taken: "このメールアドレスは既に使用されています。"
             password:
-              blank: "パスワードを入力してください。"
-  attributes:
-    email: "メールアドレス"
-    password: "パスワード"
+              blank: "を入力してください。"
+            current_password:
+              blank: "を入力してください。"
+            password_confirmation: 
+              confirmation: "を入力してください。"
   devise:
     sessions:
       user:
         signed_in: "ログインに成功しました！"
         signed_out: "ログアウトしました。"
+    registrations: 
+      user:
+        updated: "プロフィールを更新しました。"
     failure:
       user:
         invalid: "メールアドレスとパスワードが違います。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { registrations: 'users/registrations' }
   root 'playlists#index'
 
   resources :playlists, only: %i[show new create edit update destroy]


### PR DESCRIPTION
## 概要
- プロフィール編集ページで、ユーザー名と登録メールアドレスを変更できるようにしました。
- プロフィール更新時、マイページに遷移するようにしました。
- ユーザー名・登録メールアドレスをパスワードなしで変更できるようにしました。


## 今後の修正事項
### プロフィール編集ページ
- アバター画像の変更ができるようにする。
- プロフィール文を編集できるようにする。 ※他ユーザーのプロフィールページを閲覧できるように実装してから
- パスワードを変更できるようにする。
- デザインを諸々調整。