### PR TITLE
#64 曲検索機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,8 +47,10 @@ gem 'bootsnap', require: false
 
 gem 'devise'
 
+# Spotify API
 gem 'rspotify'
 
+# environment variables
 gem 'dotenv-rails'
 
 # Use Sass to process CSS

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,11 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'bootsnap', require: false
 
 gem 'devise'
+
+gem 'rspotify'
+
+gem 'dotenv-rails'
+
 # Use Sass to process CSS
 # gem "sassc-rails"
 

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem 'bootsnap', require: false
 
 gem 'devise'
 
+gem 'pry-rails'
+
 # Spotify API
 gem 'rspotify'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,14 +99,27 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    domain_name (0.6.20231109)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faraday (2.7.12)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashie (5.0.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -119,6 +132,7 @@ GEM
     jsbundling-rails (1.2.1)
       railties (>= 6.0.0)
     json (2.6.3)
+    jwt (2.7.1)
     language_server-protocol (3.17.0.3)
     loofah (2.21.4)
       crass (~> 1.0.2)
@@ -131,9 +145,13 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.5.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.1205)
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
+    multi_xml (0.6.0)
     net-imap (0.4.1)
       date
       net-protocol
@@ -143,11 +161,26 @@ GEM
       timeout
     net-smtp (0.4.0)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.9)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    omniauth (2.1.1)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     parallel (1.23.0)
     parser (3.2.2.4)
@@ -161,6 +194,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.8)
+    rack-protection (3.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.8)
@@ -202,6 +237,10 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.6)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
@@ -220,6 +259,10 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
+    rspotify (2.12.0)
+      addressable (~> 2.8.0)
+      omniauth-oauth2 (>= 1.6)
+      rest-client (~> 2.0.2)
     rubocop (1.57.1)
       base64 (~> 0.1.1)
       json (~> 2.3)
@@ -250,11 +293,15 @@ GEM
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.14.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
     spring (4.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -277,6 +324,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    version_gem (1.1.3)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -302,6 +350,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise
+  dotenv-rails
   factory_bot_rails
   jbuilder
   jsbundling-rails
@@ -310,6 +359,7 @@ DEPENDENCIES
   rails (~> 7.0.8)
   redis (~> 4.0)
   rspec-rails
+  rspotify
   rubocop
   rubocop-performance
   rubocop-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     cssbundling-rails (1.3.3)
@@ -187,6 +188,11 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (5.1.1)
       stringio
     public_suffix (5.0.3)
@@ -355,6 +361,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   pg (~> 1.1)
+  pry-rails
   puma (~> 5.0)
   rails (~> 7.0.8)
   redis (~> 4.0)

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,2 +1,8 @@
 class TracksController < ApplicationController
-end
+
+  def search
+      if params[:search].present?
+        @tracks = RSpotify::Track.search(params[:search])
+      end
+    end
+  end

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -1,4 +1,4 @@
 <div class="bg-white p-8 rounded-lg text-center w-full">
-    <h1 class="text-4xl font-bold mb-4 text-accent">Hello Mutro!</h1>
-    <p class="text-gray-700 mb-4">Welcome to Mutro. Explore and enjoy our features.</p>
+  <h1 class="text-4xl font-bold mb-4 text-accent">Hello Mutro!</h1>
+  <p class="text-gray-700 mb-4">Welcome to Mutro. Explore and enjoy our features.</p>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,9 +4,11 @@
   </div>
   <div class="flex-none gap-2">
     <% if user_signed_in? %>
-      <button class="btn btn-ghost btn-circle">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
-      </button>
+      <%= link_to search_tracks_path, class: "btn btn-ghost btn-circle" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+      <% end %>
       <div class="dropdown dropdown-end">
         <label tabindex="0" class="btn btn-ghost btn-circle avatar">
           <div class="w-10 rounded-full">

--- a/app/views/tracks/search.html.erb
+++ b/app/views/tracks/search.html.erb
@@ -1,0 +1,24 @@
+<h1 class="text-center font-bold">Tracks#search</h1>
+
+<%=form_with url:  search_tracks_path ,method: :get do |f|%>
+  <div class="mt-4 flex justify-center">
+    <%= f.search_field :search, value: params[:search], placeholder: "アーティスト名 or 曲名で検索してください", class: "w-1/2 p-3 mx-auto text-sm border-primary rounded-lg bg-slate-50 border-2", type: "text", autofocus: true %>
+  </div>
+<% end %>
+
+<% if @tracks.present? %>
+  <div class="mt-4">
+    <h2 class="text-center font-bold">検索結果</h2>
+    <div class="flex flex-wrap justify-center">
+      <% @tracks.each do |track| %>
+        <div class="flex justify-center p-2 ml-2 w-1/4">
+          <% if track.id %>
+            <iframe loading="lazy" src="https://open.spotify.com/embed/track/<%= track.id %>" width="100%" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,12 +1,14 @@
-<div class="avatar">
+<div class="ml-8 mb-4">
   <div class="w-40 rounded-full">
     <%= image_tag 'K1Ey1wwTeYA6YQM1698909468_1698909495.png' %>
   </div>
 </div>
-<div>
+<div class="ml-8 mb-4">
   <%= current_user.name %>
   <p>ユーザーID: <%= current_user.id %></p>
 </div>
-<% if user_signed_in? %>
-  <%= link_to 'プロフィール編集', edit_user_registration_path, class: 'btn btn-sm btn-outline btn-primary' %>
-<% end %>
+<div class="ml-8">
+  <% if user_signed_in? %>
+    <%= link_to 'プロフィール編集', edit_user_registration_path, class: 'btn btn-sm btn-outline btn-primary' %>
+  <% end %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,3 +10,6 @@ module Mutro
     config.i18n.default_locale = :ja
   end
 end
+
+# Spotify APIの認証情報を設定
+RSpotify::authenticate(ENV['SPOTIFY_CLIENT_ID'], ENV['SPOTIFY_CLIENT_SECRET'])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,10 @@ Rails.application.routes.draw do
 
   resources :playlists, only: %i[show new create edit update destroy]
   resources :users, only: %i[show]
+
+  resources :tracks do
+    collection do
+      get :search
+    end
+  end
 end


### PR DESCRIPTION
## 概要

RSpotifyを用いて曲検索機能（アーティスト名からの検索も可）を実装しました。
- Spotify APIを利用するためのrspotify及び環境変数管理のためのdotenv-railsのgemをインストールしました。
- Tracks#searchアクションに、RSpotifyを用いた曲検索機能を実装しました。
- 曲検索フォームと検索結果を表示するビューファイルを作成しました。（最終的にはプレイリスト作成画面で曲検索をできるように変更したい）
- ヘッダーから曲検索ぺーじに遷移できるようにリンクを作成しました。

## 影響範囲
- Tracksコントローラ
- tracks/search.html.erb

## 今後の修正事項
- 曲検索機能は、プレイリスト作成画面から利用できるようにする。
- 取り急ぎ、ヘッダーから曲検索ページへ遷移できるようリンクを作ったが後々修正。