### PR TITLE
#82 #83 プレイリスト削除・編集機能の作成

### DIFF
--- a/app/controllers/playlist_tracks_controller.rb
+++ b/app/controllers/playlist_tracks_controller.rb
@@ -1,0 +1,19 @@
+class PlaylistTracksController < ApplicationController
+  before_action :set_playlist
+  before_action :set_track, only: %i[destroy]
+
+  def destroy
+    @playlist.tracks.delete(@track)
+    redirect_to edit_playlist_path(@playlist), notice: '曲が削除されました。'
+  end
+
+  private
+
+  def set_playlist
+    @playlist = current_user.playlists.find(params[:playlist_id])
+  end
+
+  def set_track
+    @track = Track.find(params[:id])
+  end
+end

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -26,12 +26,23 @@ class PlaylistsController < ApplicationController
   end
 
   def edit
+    @playlist = current_user.playlists.find(params[:id])
   end
 
   def update
+    @playlist = current_user.playlists.find(params[:id])
+
+    if @playlist.update(playlist_params)
+      redirect_to playlist_path(@playlist), notice: 'プレイリストが更新されました'
+    else
+      render :edit
+    end
   end
 
   def destroy
+    @playlist = current_user.playlists.find(params[:id])
+    @playlist.destroy
+    redirect_to playlists_path, notice: 'プレイリストが削除されました'
   end
 
   def add_track_to_playlist

--- a/app/helpers/playlist_tracks_helper.rb
+++ b/app/helpers/playlist_tracks_helper.rb
@@ -1,0 +1,2 @@
+module PlaylistTracksHelper
+end

--- a/app/views/playlists/edit.html.erb
+++ b/app/views/playlists/edit.html.erb
@@ -1,0 +1,33 @@
+<div class="container mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold text-center mb-6">プレイリスト編集</h1>
+
+  <%= form_with model: @playlist, url: playlist_path(@playlist), method: :patch, class: "w-full max-w-2xl mx-auto bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4" do |f| %>
+    <div class="mb-4">
+      <%= f.label :title, class: "block text-gray-700 text-lg font-bold mb-2" %>
+      <%= f.text_field :title, required: true, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
+    </div>
+
+    <div class="mb-6">
+      <%= f.label :description, class: "block text-gray-700 text-sm font-bold mb-2" %>
+      <%= f.text_area :description, required: true, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline", rows: 4 %>
+    </div>
+
+    <div class="tracks-list mt-4">
+      <h2 class="text-lg font-bold mb-2">Tracks</h2>
+      <ul>
+        <% @playlist.tracks.each do |track| %>
+          <li class="flex items-center justify-between mb-2 bg-gray-100 p-2 rounded">
+            <span class="text-gray-800"><%= track.title %> - <%= track.artist %></span>
+            <%= link_to '削除', playlist_track_path(track.id, playlist_id: @playlist.id), data: { turbo_method: :delete, turbo_confirm: 'この曲を削除しますか？' }, class: "btn btn-error text-white" %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+
+
+    <div class="flex items-center justify-between">
+      <%= f.submit "更新", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>
+

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -22,5 +22,11 @@
       <p class="text-gray-600">This playlist has no tracks yet.</p>
     <% end %>
   </div>
+  <% if @playlist.user == current_user %>
+    <%= link_to 'プレイリスト編集', edit_playlist_path(@playlist), class: 'btn btn-primary m-4' %>
+  <% if current_user == @playlist.user %>
+  <%= link_to 'プレイリストを削除', playlist_path(@playlist), data: { turbo_method: :delete, turbo_confirm: 'プレイリストを削除しますか？' }, class: "btn btn-error text-white" %>
+<% end %>
+<% end %>
 </div>
 

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -22,11 +22,14 @@
       <p class="text-gray-600">This playlist has no tracks yet.</p>
     <% end %>
   </div>
-  <% if @playlist.user == current_user %>
-    <%= link_to 'プレイリスト編集', edit_playlist_path(@playlist), class: 'btn btn-primary m-4' %>
-  <% if current_user == @playlist.user %>
-  <%= link_to 'プレイリストを削除', playlist_path(@playlist), data: { turbo_method: :delete, turbo_confirm: 'プレイリストを削除しますか？' }, class: "btn btn-error text-white" %>
-<% end %>
-<% end %>
+    <% if @playlist.user == current_user %>
+      <%= link_to 'プレイリスト編集', edit_playlist_path(@playlist), class: 'btn btn-primary m-4' %>
+    <% if current_user == @playlist.user %>
+      <%= link_to 'プレイリストを削除', playlist_path(@playlist), data: { turbo_method: :delete, turbo_confirm: 'プレイリストを削除しますか？' }, class: "btn btn-error text-white" %>
+    <% end %>
+  <% end %>
+  <div class="flex justify-center mt-8">
+  <%= link_to '一覧に戻る', root_path, class: 'btn btn-outline btn-primary rounded-lg' %>
+  </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     collection do
       post :add_track_to_playlist
     end
+    resources :tracks, controller: 'playlist_tracks', only: %i[destroy]
   end
 
   resources :users, only: %i[show]

--- a/spec/helpers/playlist_tracks_helper_spec.rb
+++ b/spec/helpers/playlist_tracks_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PlaylistTracksHelper. For example:
+#
+# describe PlaylistTracksHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PlaylistTracksHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/playlist_tracks_spec.rb
+++ b/spec/requests/playlist_tracks_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "PlaylistTracks", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 概要
- PlaylistTracksコントローラを追加しました。
- 詳細ページに一覧ページへの戻るボタン、プレイリスト編集ページへのリンク、プレイリスト削除ボタン（プレイリストを作成したユーザーのみ）を実装しました。
- プレイリスト編集ページで、プレイリスト名・説明文・プレイリストの曲削除ができるようにしました。
- 

## 影響範囲
- Playlistsコントローラ
- PlaylistTracksコントローラ
- viewss/playlsits下のビューファイル

## 今後の修正事項
- プレイリスト編集で、曲順の変更をできる（できればドラッグ&ドロップ）機能の追加。
- 編集時の曲数、文字数等のバリデーションの追加