### PR TITLE
#92 プレイリストへの曲追加後の削除ボタンの実装

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,7 +248,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.1.0)
     rdoc (6.5.0)
       psych (>= 4.0.0)
     redis (4.8.1)

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -70,7 +70,7 @@ class PlaylistsController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: turbo_stream.append('playlist_preview', partial: 'playlists/track', locals: { track: @track })
+        render turbo_stream: turbo_stream.append('playlist_preview', partial: 'playlists/track_with_remove_button', locals: { track: @track })
       end
     end
   end
@@ -83,7 +83,6 @@ class PlaylistsController < ApplicationController
         render turbo_stream: turbo_stream.remove("track_#{params[:track_id]}")
       end
     end
-
   end
 
   def new_releases

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -70,9 +70,20 @@ class PlaylistsController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: turbo_stream.append('playlist_tracks', partial: 'playlists/track', locals: { track: @track })
+        render turbo_stream: turbo_stream.append('playlist_preview', partial: 'playlists/track', locals: { track: @track })
       end
     end
+  end
+
+  def remove_track_from_playlist
+    session[:current_playlist_tracks].delete(params[:track_id].to_i)
+
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.remove("track_#{params[:track_id]}")
+      end
+    end
+
   end
 
   def new_releases

--- a/app/views/playlists/_playlist_preview.html.erb
+++ b/app/views/playlists/_playlist_preview.html.erb
@@ -1,9 +1,11 @@
-<%= turbo_frame_tag "playlist_tracks" do %>
-  <div id="playlist-tracks">
+<%= turbo_frame_tag "playlist_preview" do %>
+  <div>
     <p class="text-center font-bold">Playlist ※5~20曲まで</p>
     <% @playlist.tracks.each do |track| %>
       <%= turbo_frame_tag dom_id(track) do %>
-        <%= render "playlists/track", track: track %>
+        <div class="flex justify-between items-center mb-2">
+          <%= render "playlists/track", track: track %>
+        </div>
       <% end %>
     <% end %>
   </div>

--- a/app/views/playlists/_playlist_preview.html.erb
+++ b/app/views/playlists/_playlist_preview.html.erb
@@ -4,7 +4,7 @@
     <% @playlist.tracks.each do |track| %>
       <%= turbo_frame_tag dom_id(track) do %>
         <div class="flex justify-between items-center mb-2">
-          <%= render "playlists/track", track: track %>
+          <%= render "playlists/track_with_remove_button", track: track %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/playlists/_track.html.erb
+++ b/app/views/playlists/_track.html.erb
@@ -1,5 +1,7 @@
-<%= turbo_frame_tag dom_id(track) do %>
-  <div class="m-1">
+<div id="<%= dom_id(track) %>" class="flex justify-start items-center mb-2 gap-x-4">
+  <div class="flex-grow m-1 w-full md:w-1/2 lg:w-2/3">
       <iframe src="https://open.spotify.com/embed/track/<%= track.spotify_id %>" width="100%" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
   </div>
-<% end %>
+  <%= link_to '削除', remove_track_from_playlist_playlists_path(track_id: track.id), method: :delete, data: { turbo_method: :delete, turbo_confirm: '本当にこの曲を削除しますか？' }, class: "btn btn-danger btn-sm" %>
+</div>
+

--- a/app/views/playlists/_track.html.erb
+++ b/app/views/playlists/_track.html.erb
@@ -2,6 +2,5 @@
   <div class="flex-grow m-1 w-full md:w-1/2 lg:w-2/3">
       <iframe src="https://open.spotify.com/embed/track/<%= track.spotify_id %>" width="100%" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
   </div>
-  <%= link_to '削除', remove_track_from_playlist_playlists_path(track_id: track.id), method: :delete, data: { turbo_method: :delete, turbo_confirm: '本当にこの曲を削除しますか？' }, class: "btn btn-danger btn-sm" %>
 </div>
 

--- a/app/views/playlists/_track_with_remove_button.html.erb
+++ b/app/views/playlists/_track_with_remove_button.html.erb
@@ -1,0 +1,7 @@
+<div id="<%= dom_id(track) %>" class="flex justify-start items-center mb-2 gap-x-4">
+  <div class="flex-grow m-1 w-full md:w-1/2 lg:w-2/3">
+      <iframe src="https://open.spotify.com/embed/track/<%= track.spotify_id %>" width="100%" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+  </div>
+  <%= link_to '削除', remove_track_from_playlist_playlists_path(track_id: track.id), method: :delete, data: { turbo_method: :delete, turbo_confirm: '本当にこの曲を削除しますか？' }, class: "btn btn-outline btn-error btn-sm" %>
+</div>
+

--- a/app/views/playlists/new.html.erb
+++ b/app/views/playlists/new.html.erb
@@ -11,7 +11,7 @@
   <%= render 'shared/flash' %>
 <% end %>
 
-<div class="flex justify-center items-start gap-8 ml-8">
+<div class="flex justify-center items-start ml-4">
   <div class="w-full lg:w-1/3 xl:w-2/3 mx-8 bg-white text-primary rounded-lg shadow p-4 max-h-[74vh] overflow-y-auto">
     <%= render 'playlists/playlist_preview', playlist: @playlist %>
   </div>

--- a/app/views/tracks/_search_form.html.erb
+++ b/app/views/tracks/_search_form.html.erb
@@ -1,9 +1,6 @@
-<%= turbo_frame_tag 'search_form_frame' do %>
-  <%= form_with url: search_tracks_path, method: :get, data: { turbo_frame: 'search_results' } do |f| %>
-    <div class="mt-4 flex flex-col items-center justify-center" data-controller="autocomplete" data-autocomplete-url-value="<%= search_tracks_path(format: :json) %>">
-      <%= f.search_field :search, value: params[:search], placeholder: "アーティスト名 or 曲名で検索してください", class: "w-1/2 p-3 mx-auto text-sm border-primary rounded-lg bg-slate-50 border-2", data: { autocomplete_target: "input" }, type: "text", autofocus: true, required: true %>
-      <%= f.submit "Search", class: "btn btn-sm btn-primary mx-auto text-sm rounded-lg mt-3" %>
-    </div>
-  <% end %>
+<%= form_with url: search_tracks_path, method: :get, data: { turbo_frame: 'search_results' } do |f| %>
+  <div class="mt-4 flex flex-col items-center justify-center" data-controller="autocomplete" data-autocomplete-url-value="<%= search_tracks_path(format: :json) %>">
+    <%= f.search_field :search, value: params[:search], placeholder: "アーティスト名 or 曲名で検索してください", class: "w-1/2 p-3 mx-auto text-sm border-primary rounded-lg bg-slate-50 border-2", data: { autocomplete_target: "input" }, type: "text", autofocus: true, required: true %>
+    <%= f.submit "Search", class: "btn btn-sm btn-primary mx-auto text-sm rounded-lg mt-3" %>
+  </div>
 <% end %>
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     collection do
       get :new_releases
       post :add_track_to_playlist
+      delete :remove_track_from_playlist
     end
     resources :tracks, controller: 'playlist_tracks', only: %i[destroy]
     resources :comments, only: %i[create]


### PR DESCRIPTION
## 概要
- プレイリスト作成画面で、曲を追加した後に削除するためのボタンを実装しました。
- 上記の実装に伴い、remove_track_from_playlistアクションの追加, ルーティングの追加, 削除ボタン用のパーシャルファイルの作成をしました。

## 影響範囲
- Playlistsコントローラ
- Playlistsディレクトリ下のビューファイル

## 今後の修正事項
- ボタンデザイン要検討。