### PR TITLE
レイアウトの微修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@ module ApplicationHelper
   def default_meta_tags
     {
       site: 'Mutro',
-      title: 'いつもより少しだけ時間をかけて音楽と向き合ってみませんか？',
+      title: 'プレイリスト作成・シェアサービス',
       reverse: true,
       charset: 'utf-8',
       description: 'Mutroはプレイリストを作成・シェア・視聴できるサービスです。',

--- a/app/views/playlists/_playlist_preview.html.erb
+++ b/app/views/playlists/_playlist_preview.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "playlist_preview" do %>
   <div>
-    <p class="text-center font-bold">Playlist ※5~20曲まで</p>
+    <p class="text-center font-bold">PLAYLIST ※5~20曲まで</p>
     <% @playlist.tracks.each do |track| %>
       <%= turbo_frame_tag dom_id(track) do %>
         <div class="flex justify-between items-center mb-2">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,9 +10,6 @@
         <%= link_to new_releases_playlists_path, class: "font-bold text-primary hover:text-secondary" do %>
           <i class="fa-solid fa-compact-disc" style="color: #05a1ad;"></i> NEW RELEASES
         <% end %>
-        <%= link_to root_path, class: "font-bold text-primary hover:text-secondary" do %>
-          <i class="fa-solid fa-compact-disc" style="color: #05a1ad;"></i> ALL PLAYLISTS
-        <% end %>
         <div class="dropdown dropdown-end">
           <label tabindex="0" class="mr-4 ml-4">
             <i class="fa-solid fa-2xl fa-bars" style="color: #00a2ae;"></i>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,8 @@ ja:
     attributes:
       playlist:
         tracks: "トラック"
+        title: "TITLE"
+        description: "RECOMMEND"
     errors:
       models:
         playlist:


### PR DESCRIPTION
## 概要
- ヘッダーのALL PLAYLISTSを削除
- プレイリスト作成画面の各見出しを大文字に修正
- OGPのtitleの文言を修正

## 影響範囲
- application_helper.rb
- _playlist_preview.html.erb
- config/locales/ja.yml

## 今後の修正事項
CDショップを意識したレイアウト・スタイリングの実装