### PR TITLE
#197 アプリの使い方ページの最下部にトップページへのリンクを追加

### DIFF
--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -58,12 +58,17 @@
   </div>
 
   <div class="section my-10 p-6 bg-base-100 rounded-lg shadow-md">
-  <h2 class="text-2xl font-black text-center text-accent mb-4">プレイリストをリリースするには？</h2>
-  <p class="text-lg text-gray-600">
-    1：ヘッダーの"RELEASE"をクリック</br>
-    2: 曲検索フォームにアーティスト名や曲名を入力</br>
-    3: 検索結果からプレイリストに追加したい曲を"ADD"ボタンで追加</br>
-    4: プレイリストのタイトルや説明文を入力</br>
-    5: "RELEASE A PLAYLIST!"ボタンをクリック</br>
-  </p>
+    <h2 class="text-2xl font-black text-center text-accent mb-4">プレイリストをリリースするには？</h2>
+    <p class="text-lg text-gray-600">
+      1：ヘッダーの"RELEASE"をクリック</br>
+      2: 曲検索フォームにアーティスト名や曲名を入力</br>
+      3: 検索結果からプレイリストに追加したい曲を"ADD"ボタンで追加</br>
+      4: プレイリストのタイトルや説明文を入力</br>
+      5: "RELEASE A PLAYLIST!"ボタンをクリック</br>
+    </p>
+  </div>
+
+  <div class="flex justify-center">
+    <%= link_to 'ALL PLAYLISTS', root_path, class: "btn btn-sm border-amber-500 text-amber-500 bg-white hover:bg-amber-600 hover:text-white" %>
+  </div>
 </div>


### PR DESCRIPTION
## 概要
- アプリの使い方ページをスクロールした最下部にトップページへの遷移ボタンを追加しました。

## 影響範囲
- static_pages/about.html.erb

## 今後の修正事項
- スクロール時にヘッダーを固定することを検討。