### PR TITLE
#199 アプリの使い方ページのリンクをフッターからヘッダーに移動

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,6 @@
     <p class="text-slate-500">Copyright © 2024 - All right reserved by Mutro</p>
   </aside>
   <div class="footer-links flex gap-8 text-slate-600">
-    <%= link_to 'About "Mutro"', about_path, class: 'text-primary font-black' %>
     <%= link_to 'お問い合わせ', 'https://forms.gle/BL9XpXKsqMpg4zgJA' %>
     <%= link_to '利用規約', terms_path %> 
     <%= link_to 'プライバシーポリシー', privacy_policy_path %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,6 +6,7 @@
 
     <% if user_signed_in? %>
       <div class="flex items-center gap-3">
+        <%= link_to 'About "Mutro"', about_path, class: 'text-primary font-black' %>
         <%= link_to 'Release', new_playlist_path, class: "btn btn-sm border-amber-500 text-amber-500 bg-white hover:bg-amber-600 hover:text-white" %>
         <%= link_to new_releases_playlists_path, class: "font-bold text-primary hover:text-secondary" do %>
           <i class="fa-solid fa-compact-disc" style="color: #05a1ad;"></i> NEW RELEASES


### PR DESCRIPTION
## 概要
- フッターに設置していたアプリの使い方ページのリンクをヘッダーに移動

## 影響範囲
- shared/_footer.html.erb
- shared/_footer.html.erb

## 今後の修正事項
- アプリの使い方を明示的に画面上に表示しなくても、ユーザーがわかりやすい導線にする or より直感的に使えるUIを検討。