### PR TITLE
#218 タイトルの文字数制限を30文字に変更

### DIFF
--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -7,7 +7,7 @@ class Playlist < ApplicationRecord
   belongs_to :mood, optional: true
   belongs_to :user
 
-  validates :title, presence: true, length: { maximum: 20 }
+  validates :title, presence: true, length: { maximum: 30 }
   validates :description, presence: true, length: { maximum: 10_000 }
   validate :tracks_count_within_limit
 

--- a/app/views/playlists/new.html.erb
+++ b/app/views/playlists/new.html.erb
@@ -21,7 +21,7 @@
       <div class="w-full text-center p-2">
         <%= f.label :title, class: "text-lg font-bold text-primary" %>
         <div class="flex justify-center items-center">
-          <%= f.text_field :title, required: true, placeholder: "タイトルは20文字まで", class: "form-control border-2 border-primary p-2 rounded-lg", style: "width: 340px;" %>
+          <%= f.text_field :title, required: true, placeholder: "タイトルは30文字まで", class: "form-control border-2 border-primary p-2 rounded-lg", style: "width: 480px;" %>
         </div>
       </div>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,7 +13,7 @@ ja:
             tracks:
               tracks_count_within_limit: "は5曲以上20曲以下にしてください"
             title:
-              too_long: "は20文字以内にしてください"
+              too_long: "は30文字以内にしてください"
   notices:
     comment_added: "コメントしました。"
     comment_failed: "コメントに失敗しました。"


### PR DESCRIPTION
## 概要
- プレイリスト作成時のタイトルの文字数制限を30文字以内に変更しました

## 影響範囲
- app/models/playlist.rb
- app/views/playlists/new.html.erb
- config/locales/ja.yml

## 今後の修正事項